### PR TITLE
feat: improved logging

### DIFF
--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -120,6 +120,7 @@ func createClient(ctx context.Context, logger zerolog.Logger) (*http.Client, err
 	)
 
 	if token != nil {
+		logger.Debug().Msg("Found environment variable with GitHub token")
 		return util.NewTokenHTTPClient(ctx, logger, *token), nil
 	}
 
@@ -141,8 +142,11 @@ func createClient(ctx context.Context, logger zerolog.Logger) (*http.Client, err
 	)
 
 	if appID != nil && installationID != nil && appPrivKey != nil {
+		logger.Debug().Msg("Found environment variables for GitHub App authentication")
 		return util.NewInstallationHTTPClient(ctx, logger, *appID, *installationID, *appPrivKey)
 	}
+
+	logger.Debug().Msg("Using an unauthenticated GitHub client")
 
 	return http.DefaultClient, nil
 }

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -44,12 +44,8 @@ type Reposaur struct {
 // The default HTTP client will use the default host `api.github.com`. Can
 // be customized using the `GITHUB_HOST` or `GH_HOST` environment variables.
 func New(ctx context.Context, policyPaths []string, opts ...Option) (*Reposaur, error) {
-	cw := zerolog.NewConsoleWriter()
-	cw.Out = os.Stderr
-	logger := zerolog.New(cw).With().Timestamp().Logger()
-
 	sdk := &Reposaur{
-		logger: logger,
+		logger: zerolog.New(os.Stderr),
 	}
 
 	for _, opt := range opts {

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -32,6 +32,11 @@ func (t githubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.URL.Host = ghHost
 	req.URL.Scheme = "https"
 
+	t.logger.Debug().
+		Str("method", req.Method).
+		Str("url", req.URL.String()).
+		Msg("Sending request to GitHub")
+
 	return t.throttle(req)
 }
 

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -61,9 +61,9 @@ func (t *githubTransport) throttle(req *http.Request) (*http.Response, error) {
 		Dur("retry after", retryAfter).
 		Logger()
 
-	logger.Info().Msg("Hit secondary rate limit. Waiting before trying...")
+	logger.Info().Msg("Hit secondary rate limit. Waiting before trying")
 	time.Sleep(retryAfter)
-	logger.Info().Msg("Continuing...")
+	logger.Info().Msg("Continuing")
 
 	return t.RoundTrip(req)
 }


### PR DESCRIPTION
- Removed the custom logger in the SDK in favor of the default one (let the SDK users decide how they want their logs to be formatted)
- Added `-logger-format` and `--logger-level, -l` flags to customize the logs via the CLI
- Added debug logs in several places related with the creation of the default GitHub client and HTTP requests

In practice from the CLI usage PoV nothing will change in terms of output since the default values for the flags mentioned
above are the same as before.