### PR TITLE
fix(errors): error abstractions refactoring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ gh api /repos/reposaur/reposaur | reposaur
 ## Executing the policies against every repository in an organization
 
 ```shell
-$ gh api /orgs/reposaur/repos --paginate | reposaur
+$ gh api /orgs/reposaur/repos --paginate | jq -s add | reposaur
 # [{ ... }, ...]
 ```
 

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -24,11 +24,11 @@ func Load(ctx context.Context, policyPaths []string) (*Engine, error) {
 		WithProcessAnnotation(true).
 		Filtered(policyPaths, isRegoFile)
 	if err != nil {
-		return nil, &PolicyLoaderError{err}
+		return nil, &ErrPolicyLoad{err}
 	}
 
 	if len(policies.Modules) == 0 {
-		return nil, &NoPoliciesError{policyPaths}
+		return nil, &ErrNoPolicies{policyPaths}
 	}
 
 	modules := policies.ParsedModules()

--- a/internal/policy/errors.go
+++ b/internal/policy/errors.go
@@ -1,0 +1,19 @@
+package policy
+
+import "fmt"
+
+type PolicyLoaderError struct {
+	loaderError error
+}
+
+func (e *PolicyLoaderError) Error() string {
+	return fmt.Sprintf("load: %v", e.loaderError)
+}
+
+type NoPoliciesError struct {
+	policyPaths []string
+}
+
+func (e *NoPoliciesError) Error() string {
+	return fmt.Sprintf("no policy .rego files found in %v", e.policyPaths)
+}

--- a/internal/policy/errors.go
+++ b/internal/policy/errors.go
@@ -2,18 +2,18 @@ package policy
 
 import "fmt"
 
-type PolicyLoaderError struct {
+type ErrPolicyLoad struct {
 	loaderError error
 }
 
-func (e *PolicyLoaderError) Error() string {
+func (e *ErrPolicyLoad) Error() string {
 	return fmt.Sprintf("load: %v", e.loaderError)
 }
 
-type NoPoliciesError struct {
+type ErrNoPolicies struct {
 	policyPaths []string
 }
 
-func (e *NoPoliciesError) Error() string {
+func (e *ErrNoPolicies) Error() string {
 	return fmt.Sprintf("no policy .rego files found in %v", e.policyPaths)
 }


### PR DESCRIPTION
After working with the code a bit I noticed the cause for both the new exception are different so I decided to split the previously discussed error into 2: one is related to a OPA loader error and we just manage to wrap it and the other is actually related to the policy files.
Since I actually found the `Filtered` method for the loader a quite clean solution, I decided to keep it and extracted the actual predicate for better readability. This implies that we cannot find out what are the files as they might have been filtered out but I believe that after inlining the `allRepos()` function it reads a bit better than before and we do not obfuscate the errors purposes as much.
In terms of the NoPolicyError found I rephrased its message to `no policy .rego files found in "path"` as it no longer implies that there are no policy files but rather that there aren't no .rego policy files that might help better indicate any issue.
