### PR TITLE
feat: allow to load modules dynamically

### DIFF
--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -60,9 +60,13 @@ func New(ctx context.Context, policyPaths []string, opts ...Option) (*Reposaur, 
 
 	var err error
 
-	sdk.engine, err = policy.Load(ctx, policyPaths)
-	if err != nil {
-		return nil, err
+	if len(policyPaths) == 0 {
+		sdk.engine = policy.New()
+	} else {
+		sdk.engine, err = policy.Load(ctx, policyPaths)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return sdk, nil


### PR DESCRIPTION
Enables loading modules dynamically (instead at initialization time) to support use cases where we don't have a filesystem or want to add new policies at runtime (i.e. the playground).