### PR TITLE
chore: improvements to install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /policy/
 /testdata/events/_*.json
 dist/
+bin/
 
 # Generated
 /completions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+Beforehand, thank you for considering contributing to Reposaur! We welcome and
+appreciate any help we can get.
+
+Contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Feedback and Questions
+
+We appreciate any feedback we can get and are happy to answer any questions you
+might have!
+
+Reach out to us in [Discussions][discussions] or in our [Slack Workspace][slack].
+
+## Bug Reporting and Feature Requests
+
+### Bug Reports
+
+If you've found an issue in the CLI, SDK or Policy Engine, please
+[open a bug report][bug-report]. We appreciate the feedback and will try to help
+as soon as possible. The form will guide you on how to report the bug.
+
+### Feature Requests
+
+If you've an exiting idea, new use case or anything else, we'd love to hear it!
+Please, [open a feature request][feature-request] and share it with the community!
+The form will guide you on how to request a new feature.
+
+## Development
+
+To get your development environment ready you'll need to have the following
+installed:
+
+- [Go][go] >= 1.18
+- [Task][task] >= 3.0
+
+### Setting up
+
+Fork the repository to your account and clone it to your machine. Build for the
+first time and make sure everything is working as expected:
+
+```console
+$ task build
+```
+
+If you don't have Task installed you can issue the following commands:
+
+```console
+go mod tidy
+go build -o ./.bin/rsr ./cmd/rsr/rsr.go \
+    -ldflags "-s -w -X github.com/reposaur/reposaur/internal/build.Version=devel"
+```
+
+After the command above you should have `rsr` available in `./.bin`:
+
+```console
+$ ./.bin/rsr --version
+rsr version devel
+```
+
+Happy coding!
+
+### Creating a Pull Request
+
+We don't have any rigid structure for Pull Requests right now, although that's
+expected to change in the future.
+
+For now, just explain briefly what your changes address and link any related
+issues or other Pull Requests.
+
+Creating an [issue][issues] prior to the Pull Request is highly recommended to
+avoid multiple people working on the same issue, resulting in duplicated effort.
+
+Visit the [Pull Requests][pulls] page.
+
+## Releasing
+
+To create new releases you'll need to have following tools installed:
+
+- [GoReleaser][goreleaser] >= 1.9
+- [svu][svu] >= 1.9
+
+[discussions]: https://github.com/orgs/reposaur/discussions
+[issues]: https://github.com/reposaur/reposaur/issues
+[pulls]: https://github.com/reposaur/reposaur/pulls
+[bug-report]: https://github.com/reposaur/reposaur/issues/new?assignees=&labels=bug%2Ctriage&template=bug_report.yml&title=%5BBug%5D%3A+
+[feature-request]: https://github.com/reposaur/reposaur/issues/new?assignees=&labels=enhancement%2Ctriage&template=feature_request.yml&title=%5BFeature%5D%3A+
+[slack]: https://slack.reposaur.com
+[go]: https://go.dev/
+[task]: https://taskfile.dev/
+[goreleaser]: https://goreleaser.com
+[svu]: https://github.com/caarlos0/svu

--- a/README.md
+++ b/README.md
@@ -85,9 +85,13 @@ $ curl -sfL https://get.reposaur.com | bash
 
 We appreciate every contribution, thanks for considering it!
 
+**TLDR;**
+
 - [Open an issue][issues] if you have a problem or found a bug
 - [Open a Pull Request][pulls] if you have a suggestion, improvement or bug fix
 - [Open a Discussion][discussions] if you have questions or want to discuss ideas
+
+Check our [Contributing Guide](CONTRIBUTING.md) for more detailed information.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
 <div align="center">
 
-  [![logo][logo]][website]
-  # Reposaur
+[![logo][logo]][website]
 
-  [![go-report][go-report-badge]][go-report]
-  [![tests-workflow][tests-workflow-badge]][tests-workflow]
-  [![license][license-badge]]()
-  [![discussions][discussions-badge]][discussions]
-  [![slack][slack-badge]][slack-invite]
-  [![twitter][twitter-badge]][twitter]
+# Reposaur
 
-  **Reposaur is the open source compliance tool for development platforms.**
+[![go-report][go-report-badge]][go-report]
+[![tests-workflow][tests-workflow-badge]][tests-workflow]
+[![license][license-badge]]()
+[![discussions][discussions-badge]][discussions]
+[![slack][slack-badge]][slack-invite]
+[![twitter][twitter-badge]][twitter]
 
-  Audit, verify and report on your data and configurations easily with pre-defined and/or custom policies. <br />
-  Supports GitHub. GitLab, BitBucket and Gitea support soon.
-	
-  ⚠️ before 1.0.0 expect some bugs and API changes ⚠️
-	
-  [Getting started](#getting-started) • 
-  [Installation](#installation) • 
-  [Documentation][docs] • 
-  [Guides](#guides) • 
-  [Integrations](#integrations)
+**Reposaur is the open source compliance tool for development platforms.**
+
+Audit, verify and report on your data and configurations easily with pre-defined and/or custom policies. <br />
+Supports GitHub. GitLab, BitBucket and Gitea support soon.
+⚠️ before 1.0.0 expect some bugs and API changes ⚠️
+[Getting started](#getting-started) •
+[Installation](#installation) •
+[Documentation][docs] •
+[Guides](#guides) •
+[Integrations](#integrations)
 
 </div>
 
@@ -29,7 +28,7 @@
 
 Have you ever felt like you don't know what's happening in your GitHub/GitLab/BitBucket repositories? Between 100s or 1000s of them it's hard to make sure every single one is compliant to certain security and best practices guidelines.
 
-Reposaur is here to fix that, empowering you to focus on your work instead of hunting for issues and misconfigurations. 
+Reposaur is here to fix that, empowering you to focus on your work instead of hunting for issues and misconfigurations.
 
 ## Features
 
@@ -66,8 +65,11 @@ $ go install github.com/reposaur/reposaur/cmd/rsr@latest
 
 #### Script
 
+The script will download the latest release to a temporary directory and decompress
+it to `$HOME/.reposaur`.
+
 ```shell
-$ curl -o- https://raw.githubusercontent.com/reposaur/reposaur/main/install.sh | bash
+$ curl -sfL https://get.reposaur.com | bash
 ```
 
 # Integrations

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ This project is released under the [MIT License](LICENSE).
 [twitter-badge]: https://img.shields.io/badge/twitter-%40reposaurhq-blueviolet?style=flat-square
 [github]: https://github.com
 [github-app]: https://docs.reposaur.com/integrations/github-app
-[github-actions]: https://docs.reposaur.com/integrations/github-actions
-[github-provider]: https://docs.reposaur.com/integrations/github-provider
+[github-actions]: https://docs.reposaur.com/integrations/github-actions/setup-reposaur
+[github-provider]: https://docs.reposaur.com/
 [gitlab]: https://gitlab.com
 [gitea]: https://gitea.io
 [bitbucket]: https://bitbucket.org

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,29 @@
+# https://taskfile.dev
+
+version: "3"
+
+vars:
+  GREETING: Hello, World!
+
+tasks:
+  deps:
+    run: once
+    cmds:
+      - go mod tidy
+    silent: true
+
+  build:
+    deps: [deps]
+    vars:
+      VERSION: devel
+    cmds:
+      - go build -ldflags "-s -w -X github.com/reposaur/reposaur/internal/build.Version={{.VERSION}}" -o ./.bin/rsr ./cmd/rsr/rsr.go
+    silent: true
+
+  release:
+    cmds:
+      - git tag $(svu)
+      - git push --tags
+      - goreleaser --rm-dist
+      - defer: rm -rf dist
+    silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,7 +17,7 @@ tasks:
     vars:
       VERSION: devel
     cmds:
-      - go build -ldflags "-s -w -X github.com/reposaur/reposaur/internal/build.Version={{.VERSION}}" -o ./.bin/rsr ./cmd/rsr/rsr.go
+      - go build -ldflags "-s -w -X github.com/reposaur/reposaur/internal/build.Version={{.VERSION}}" -o ./bin/rsr ./cmd/rsr/rsr.go
     silent: true
 
   release:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,9 +2,6 @@
 
 version: "3"
 
-vars:
-  GREETING: Hello, World!
-
 tasks:
   deps:
     run: once

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,3 +27,12 @@ tasks:
       - goreleaser --rm-dist
       - defer: rm -rf dist
     silent: true
+
+  unreleased:
+    desc: Prints the commits between main branch and latest version
+    vars:
+      VERSION:
+        sh: "[ '{{.VERSION}}' != '' ] && echo '{{.VERSION}}' || curl -s https://api.github.com/repos/reposaur/reposaur/releases/latest | jq -r '.tag_name'"
+    cmds:
+      - git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit main...{{.VERSION}}
+    silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -18,8 +18,12 @@ tasks:
     silent: true
 
   release:
+    vars:
+      VERSION:
+        sh: "[ '{{.VERSION}}' != '' ] && echo '{{.VERSION}}' || svu"
     cmds:
-      - git tag $(svu)
+      - git checkout main
+      - git tag {{.VERSION}}
       - git push --tags
       - goreleaser --rm-dist
       - defer: rm -rf dist


### PR DESCRIPTION
This PR improves our `install.sh` script and how Reposaur is installed using `curl`:

```console
$ curl -sfL https://get.reposaur.com | bash
```

---

I took the opportunity for some house-cleaning and added a few more things:

- Added a [Taskfile](https://taskfile.dev/) (to improve DX)
- Added a Contributing Guide