### PR TITLE
feat: experimental bundle support

### DIFF
--- a/cmd/rsr/internal/bundle/bundle.go
+++ b/cmd/rsr/internal/bundle/bundle.go
@@ -1,0 +1,65 @@
+package bundle
+
+import (
+	"os"
+
+	"github.com/reposaur/reposaur/cmd/rsr/internal/cmdutil"
+	"github.com/reposaur/reposaur/pkg/sdk"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+)
+
+type bundleParams struct {
+	policyPaths    []string
+	experimental bool
+}
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bundle [-p POLICY_PATH...] <OUTPUT>",
+		Short: "Creates a bundle from the policies at POLICY_PATH (experimental)",
+		Long:  "Creates a bundle from the policies at POLICY_PATH (experimental)",
+	}
+
+	var (
+		params = &bundleParams{}
+		flags  = cmd.Flags()
+	)
+
+	cmdutil.AddPolicyPathsFlag(flags, &params.policyPaths)
+	cmdutil.AddExperimentalFlag(flags, &params.experimental)
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		var (
+			ctx    = cmd.Context()
+			logger = zerolog.Ctx(ctx)
+		)
+
+		if !params.experimental {
+			logger.Fatal().Msg("experimental feature, please use --experimental to accept")
+		}
+
+		if len(args) != 1 {
+			logger.Fatal().Msgf("exactly 1 arguments required, got %d", len(args))
+		}
+
+		rsr, err := sdk.New(ctx, params.policyPaths, sdk.WithLogger(*logger))
+		if err != nil {
+			logger.Fatal().Err(err).Msg("could not instantiate SDK")
+		}
+
+		out, err := os.OpenFile(args[0], os.O_WRONLY+os.O_CREATE+os.O_TRUNC, 0o666)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("could not open file")
+		}
+
+		err = rsr.Bundle(ctx, params.policyPaths, out)
+		if err != nil {
+			logger.Fatal().Err(err).Msg("could not create bundle")
+		}
+
+		logger.Info().Msgf("bundle written to %s", args[0])
+	}
+
+	return cmd
+}

--- a/cmd/rsr/internal/cmdutil/flag.go
+++ b/cmd/rsr/internal/cmdutil/flag.go
@@ -38,6 +38,10 @@ func AddVerboseFlag(flags *pflag.FlagSet, p *bool) {
 	flags.BoolVarP(p, "verbose", "v", false, "print debug logs")
 }
 
+func AddExperimentalFlag(flags *pflag.FlagSet, p *bool) {
+	flags.BoolVar(p, "experimental", false, "accepts the usage of experimental features")
+}
+
 func AddGitHubFlags(flags *pflag.FlagSet, p *GitHubClientOptions) {
 	var (
 		defURL            = getEnv("GH_API_URL", "GITHUB_API_URL")

--- a/cmd/rsr/internal/root/root.go
+++ b/cmd/rsr/internal/root/root.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"github.com/reposaur/reposaur/cmd/rsr/internal/bundle"
 	"github.com/reposaur/reposaur/cmd/rsr/internal/cmdutil"
 	"github.com/reposaur/reposaur/cmd/rsr/internal/exec"
 	"github.com/reposaur/reposaur/cmd/rsr/internal/test"
@@ -34,6 +35,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(
 		exec.NewCmd(),
 		test.NewCmd(),
+		bundle.NewCmd(),
 	)
 
 	return cmd

--- a/go.sum
+++ b/go.sum
@@ -850,7 +850,6 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
-github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.4.1-0.20220518005708-5b11656e45a6 h1:ZJP9YsKKchlGIzA244dN/irSLKpPUy3DNaopNrz03nE=
 github.com/spf13/cobra v1.4.1-0.20220518005708-5b11656e45a6/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -188,6 +188,7 @@ func (sdk Reposaur) Test(ctx context.Context) ([]*tester.Result, error) {
 	return rawResults, nil
 }
 
+// Bundle builds a new OCI-compatible policy bundle.
 func (sdk Reposaur) Bundle(ctx context.Context, paths []string, out io.Writer) error {
 	c := compile.New().
 		WithOutput(out).

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
+	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/tester"
 	"github.com/open-policy-agent/opa/topdown"
@@ -15,6 +17,7 @@ import (
 	"github.com/reposaur/reposaur/pkg/output"
 	"github.com/reposaur/reposaur/provider"
 	"github.com/reposaur/reposaur/provider/github"
+
 	"github.com/rs/zerolog"
 )
 
@@ -183,4 +186,17 @@ func (sdk Reposaur) Test(ctx context.Context) ([]*tester.Result, error) {
 	}
 
 	return rawResults, nil
+}
+
+func (sdk Reposaur) Bundle(ctx context.Context, paths []string, out io.Writer) error {
+	c := compile.New().
+		WithOutput(out).
+		WithTarget("rego").
+		WithPaths(paths...)
+
+	if err := c.Build(ctx); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Closes #29 

We use OPA's `compile` package to build a bundle of policies.

I'm labeling this as experimental since I still want to test the implementation of push/pull to OCI Registries, see if it requires any further customization. There's also another flag I'd like to have implemented afterwards (`--revision`). The API will also have to change to accommodate more options apart from output. 

Requires the `--experimental` flag to work.